### PR TITLE
added functions to spawn robots at desired world positions and orientations

### DIFF
--- a/include/rtt_gazebo_embedded/rtt_gazebo_embedded.hh
+++ b/include/rtt_gazebo_embedded/rtt_gazebo_embedded.hh
@@ -18,6 +18,8 @@
 
 // RST-RT headers
 #include <rst-rt/kinematics/JointAngles.hpp>
+#include <rst-rt/geometry/Translation.hpp>
+#include <rst-rt/geometry/Rotation.hpp>
 
 #include <thread>
 
@@ -33,6 +35,10 @@ public:
 
 	bool spawnModelAtPos(const std::string& instanceName,
 			const std::string& modelName, double x, double y, double z);
+	bool spawnModelAtPosition(const std::string& instanceName,
+			const std::string& modelName, rstrt::geometry::Translation t);
+	bool spawnModelAtPositionAndOrientation(const std::string& instanceName,
+			const std::string& modelName, rstrt::geometry::Translation t, rstrt::geometry::Rotation r);
 
 	/**
 	 * Sets the initial configuration for a specific model that was spawned before.
@@ -105,7 +111,7 @@ protected:
 private:
 	bool spawnModelInternal(const std::string& instanceName,
 			const std::string& modelName, const int timeoutSec, double x,
-			double y, double z);
+			double y, double z, double roll, double pitch, double yaw);
 	void handleURDF(TiXmlElement* robotElement,
 			gazebo::math::Vector3 initial_xyz,
 			gazebo::math::Quaternion initial_q);


### PR DESCRIPTION
I reviewed the code and it seems to be valid. It also passed my basic tests.

```python
import("rtt_gazebo_embedded")
loadComponent("gazebo","RTTGazeboEmbedded")
setActivity("gazebo",0,10,ORO_SCHED_OTHER)
gazebo.add_plugin("libRTTGazeboClockPlugin.so")
gazebo.configure()
gazebo.start()
gazebo.toggleDynamicsSimulation(false)

gazebo.spawn_model("kuka", "model://kuka-lwr-4plus", 10)
gazebo.spawn_model_at_position("kuka2", "model://kuka-lwr-4plus", rstrt.geometry.Translation(3,0,0))
gazebo.spawn_model_at_position_and_orientation("kuka3", "model://kuka-lwr-4plus", rstrt.geometry.Translation(3,0,0), rstrt.geometry.Rotation(1,0,1,0))
```

![spawnmodel](https://cloud.githubusercontent.com/assets/7841720/26242779/e2dcd714-3c89-11e7-8877-08f8eb816f3c.png)
